### PR TITLE
Add `userrole <role> inherit` and `role` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,15 @@ Role variables
 
 | Key        | Type                      | Description                                             | Support               |
 |------------|---------------------------|---------------------------------------------------------|-----------------------|
-| ``userrole`` | stirng (required) | Configures the role name which can be configured for users | dellos9 |
+| ``userrole`` | string (required) | Configures the role name which can be configured for users | dellos9 |
 | ``userrole_state`` | string: absent,present\* | Deletes the user role with specified name if set to absent | dellos9 |
+| ``userrole_inherit`` | string | Configures the existing role from which to inherit permissions (optional) | dellos9 |
+| ``role_permission`` | dictionary     | Configures command permissions for roles (see ``role_permission.\*`` | dellos9 |
+| ``role_permission.mode`` | string: configure,exec,interface,line,route-map,router     | Configures the mode for the role permission | dellos9 |
+| ``role_permission.action`` | string: reset,absent,present\*     | Configures whether to ``addrole``, ``deleterole``, or ``reset`` | dellos9 |
+| ``role_permission.role_name`` | string     | Configures the role name for the permission action | dellos9 |
+| ``role_permission.line`` | string     | Configures the LINE for the role permission (command to modify permission of) | dellos9 |
+| ``role_permission.state`` | absent,present\*     | Resets the role to its original setting | dellos9 |
 | ``username`` | string (required)         | Configures the username which must adhere to specific format guidelines (valid usernames begin with A-Z, a-z, or 0-9 and can also contain `@#$%^&*-_= +;<>,.~` characters) | dellos6, dellos9, dellos10 |
 | ``password`` | string                    | Configures the password set for the username; password length must be at least eight characters in dellos10 and dellos6 devices | dellos6, dellos9, dellos10 |
 | ``role`` | string                    | Configures the role assigned to the user | dellos9, dellos10 |
@@ -35,7 +42,7 @@ Role variables
 | ``secret_key`` | integer: 0\*,5 | Configures the secret line password using md5 encrypted algorithm | dellos9 |
 | ``state`` | string: absent,present\*     | Deletes a user account if set to absent  | dellos6, dellos9, dellos10 |
 
-> **NOTE**: Asterisk (\*) denotes the default value if none is specified. 
+> **NOTE**: Asterisk (\*) denotes the default value if none is specified.
 
 Connection variables
 --------------------
@@ -63,11 +70,11 @@ The *dellos-users* role is built on modules included in the core Ansible code. T
 Example playbook
 ----------------
 
-This role is abstracted using the *ansible_network_os* variable that can take dellos9, dellos6, and dellos10 values. If *dellos_cfg_generate* is set to true, the variable generates the role configuration commands in a file. It writes a simple playbook that only references the *dellos-users* role. By including the role, you automatically get access to all of the tasks to configure user features. 
+This role is abstracted using the *ansible_network_os* variable that can take dellos9, dellos6, and dellos10 values. If *dellos_cfg_generate* is set to true, the variable generates the role configuration commands in a file. It writes a simple playbook that only references the *dellos-users* role. By including the role, you automatically get access to all of the tasks to configure user features.
 
 **Sample hosts file**
- 
-    leaf1 ansible_host= <ip_address> 
+
+    leaf1 ansible_host= <ip_address>
 
 **Sample host_vars/leaf1**
 
@@ -79,10 +86,11 @@ This role is abstracted using the *ansible_network_os* variable that can take de
     ansible_ssh_pass: xxxxx
     ansible_network_os: dellos9
     build_dir: ../temp/dellos9
-	  
+
     dellos_users:
        - userrole: role1
          userrole_state: present
+         userrole_inherit: netoperator
        - username: u1
          password: test
          role: sysadmin
@@ -101,6 +109,12 @@ This role is abstracted using the *ansible_network_os* variable that can take de
          privilege: 3
          role: sysadmin
          state: present
+      - role_permission:
+          mode: configure
+          action: addrole
+          role_name: 'netoperator'
+          line: 'protocol spanning-tree'
+          state: present
 
 **Simple playbook to setup users - leaf.yaml**
 

--- a/templates/dellos9_users.j2
+++ b/templates/dellos9_users.j2
@@ -43,7 +43,7 @@ no username {{ item.username }}
       {% endfor %}
 no userrole {{ item.userrole }}
     {% else %}
-      {% if item.userrole_inherit is defined and item.userrole_inherit }
+      {% if item.userrole_inherit is defined and item.userrole_inherit %}
 userrole {{ item.userrole }} inherit {{ item.userrole_inherit }}
       {% else %}
 userrole {{ item.userrole }}
@@ -51,23 +51,21 @@ userrole {{ item.userrole }}
     {% endif %}
   {% endif %}
   {% if item.role_permission is defined and item.role_permission %}
-    {% for rolelist in item.role_permission %}
-      {% if rolelist.mode is defined and (rolelist.mode == "configure" or rolelist.mode == "exec" or rolelist.mode == "interface" or rolelist.mode == "line" or rolelist.mode == "route-map" or rolelist.mode == "router") %}
-        {% if rolelist.action is defined and (rolelist.action == "reset" or rolelist.action == "addrole" or rolelist.action == "deleterole") %}
-          {% if rolelist.line is defined and rolelist.line %}
-            {% if rolelist.action != "reset" and rolelist.role_name is defined and rolelist.role_name %}
-              {% if rolelist.state is defined and rolelist.state == "absent" %}
-no role {{ rolelist.mode }} {{ rolelist.action }} {{ rolelist.role_name }} {{ rolelist.line }}
-              {% else %}
-role {{ rolelist.mode }} {{ rolelist.action }} {{ rolelist.role_name }} {{ rolelist.line }}
-              {% endif %}
+    {% if item.role_permission.mode is defined and (item.role_permission.mode == "configure" or item.role_permission.mode == "exec" or item.role_permission.mode == "interface" or item.role_permission.mode == "line" or item.role_permission.mode == "route-map" or item.role_permission.mode == "router") %}
+      {% if item.role_permission.action is defined and (item.role_permission.action == "reset" or item.role_permission.action == "addrole" or item.role_permission.action == "deleterole") %}
+        {% if item.role_permission.line is defined and item.role_permission.line %}
+          {% if item.role_permission.action != "reset" and item.role_permission.role_name is defined and item.role_permission.role_name %}
+            {% if item.role_permission.state is defined and item.role_permission.state == "absent" %}
+norole {{ item.role_permission.mode }} {{ item.role_permission.action }} {{ item.role_permission.role_name }} {{ item.role_permission.line }}
             {% else %}
-role {{ rolelist.mode }} reset {{ rolelist.line }}
+role {{ item.role_permission.mode }} {{ item.role_permission.action }} {{ item.role_permission.role_name }} {{ item.role_permission.line }}
             {% endif %}
+          {% else %}
+role {{ item.role_permission.mode }} reset {{ item.role_permission.line }}
           {% endif %}
         {% endif %}
       {% endif %}
-    {% endfor %}
+    {% endif %}
   {% endif %}
   {% if item.username is defined and item.username %}
     {% if item.state is defined and item.state == "absent" %}

--- a/templates/dellos9_users.j2
+++ b/templates/dellos9_users.j2
@@ -78,13 +78,13 @@ no username {{ item.username }}
 {% set passwd = item.password %}
         {% endif %}
           {% if item.privilege is defined and item.privilege and item.access_class is defined and item.access_class and item.role is defined and item.role %}
-username {{ item.username }} password {{ passwd }} role {{ item.role }} privilege {{ item.privilege }} access-class {{ item.access_class }}
+username {{ item.username }} password {{ passwd }} privilege {{ item.privilege }} role {{ item.role }} access-class {{ item.access_class }}
           {% elif item.role is defined and item.role and item.privilege is defined and item.privilege %}
-username {{ item.username }} password {{ passwd }} role {{ item.role }} privilege {{ item.privilege }}
+username {{ item.username }} password {{ passwd }} privilege {{ item.privilege }} role {{ item.role }}
           {% elif item.role is defined and item.role and item.access_class is defined and item.access_class %}
-username {{ item.username }} password {{ passwd }} role {{ item.role }} access-class {{ item.access_class }}
+username {{ item.username }} password {{ passwd }} access-class {{ item.access_class }} role {{ item.role }}
           {% elif item.privilege is defined and item.privilege and item.access_class is defined and item.access_class %}
-username {{ item.username }} password {{ passwd }} privilege {{ item.privilege }} access-class {{ item.access_class }}
+username {{ item.username }} password {{ passwd }} access-class {{ item.access_class }} privilege {{ item.privilege }}
           {% elif item.role is defined and item.role %}
 username {{ item.username }} password {{ passwd }} role {{ item.role }}
           {% elif item.privilege is defined and item.privilege %}

--- a/templates/dellos9_users.j2
+++ b/templates/dellos9_users.j2
@@ -7,6 +7,7 @@ Configure users commands for dellos9 Devices
 dellos_users:
    - userrole: role1
      userrole_state: present
+     userrole_inherit: rolename
    - username: test
      password: test
      pass_key: 7
@@ -27,7 +28,7 @@ dellos_users:
      privilege: 3
      role: sysadmin
      state: present
-      
+
 ###################################################}
 {% if dellos_users is defined and dellos_users %}
 {% for item in dellos_users %}
@@ -42,8 +43,31 @@ no username {{ item.username }}
       {% endfor %}
 no userrole {{ item.userrole }}
     {% else %}
+      {% if item.userrole_inherit is defined and item.userrole_inherit }
+userrole {{ item.userrole }} inherit {{ item.userrole_inherit }}
+      {% else %}
 userrole {{ item.userrole }}
+      {% endif %}
     {% endif %}
+  {% endif %}
+  {% if item.role_permission is defined and item.role_permission %}
+    {% for rolelist in item.role_permission %}
+      {% if rolelist.mode is defined and (rolelist.mode == "configure" or rolelist.mode == "exec" or rolelist.mode == "interface" or rolelist.mode == "line" or rolelist.mode == "route-map" or rolelist.mode == "router") %}
+        {% if rolelist.action is defined and (rolelist.action == "reset" or rolelist.action == "addrole" or rolelist.action == "deleterole") %}
+          {% if rolelist.line is defined and rolelist.line %}
+            {% if rolelist.action != "reset" and rolelist.role_name is defined and rolelist.role_name %}
+              {% if rolelist.state is defined and rolelist.state == "absent" %}
+no role {{ rolelist.mode }} {{ rolelist.action }} {{ rolelist.role_name }} {{ rolelist.line }}
+              {% else %}
+role {{ rolelist.mode }} {{ rolelist.action }} {{ rolelist.role_name }} {{ rolelist.line }}
+              {% endif %}
+            {% else %}
+role {{ rolelist.mode }} reset {{ rolelist.line }}
+            {% endif %}
+          {% endif %}
+        {% endif %}
+      {% endif %}
+    {% endfor %}
   {% endif %}
   {% if item.username is defined and item.username %}
     {% if item.state is defined and item.state == "absent" %}


### PR DESCRIPTION
This is an attempt to add support in this module for both `userrole
<role> inherit <rolename>` and the whole `role` command tree.

https://www.dell.com/support/manuals/us/en/04/force10-s4048-on/s4048_on_9.9.0.0_config_pub-v1/modifying-command-permissions-for-roles?guid=guid-f0cec01e-f29f-4114-b6f8-faa246dd14f2&lang=en-us

Comments welcome...